### PR TITLE
Set gutters to 0 for the main layout and layout-1

### DIFF
--- a/src/style.less
+++ b/src/style.less
@@ -62,6 +62,7 @@ p{
 
 .layout{
 	.mw-ui-one-whole;
+	.mw-ui-gutter(0);
 	margin-bottom: 4em;
 }
 
@@ -79,6 +80,7 @@ p.layout-1-copy{
 	.mw-ui-one-half;
 	.mw-ui-one-whole(@palm);
 	.mw-ui-one-whole(@lap);
+	.mw-ui-gutter(0);
 	margin-top: 0;
 }
 
@@ -88,6 +90,7 @@ div.layout-1-img{
 	.mw-ui-one-half;
 	.mw-ui-one-whole(@palm);
 	.mw-ui-one-whole(@lap);
+	.mw-ui-gutter(0);
 }
 
 //LAYOUT 2 ----------------------------------------------------------------------------------


### PR DESCRIPTION
As @pauginer mentioned in pauginer/agora-grid#4 using the `mw-ui-gutter()` mixin you can get rid of the extra space.

This is what it looks like with the change—
![screen shot 2015-03-27 at 2 10 08 pm](https://cloud.githubusercontent.com/assets/9491/6864755/b62bea56-d48b-11e4-9add-5ee59255a74b.png)
